### PR TITLE
SPPermissionLocation fix

### DIFF
--- a/Source/SPPermissions/Permissions/SPPermissionLocation.swift
+++ b/Source/SPPermissions/Permissions/SPPermissionLocation.swift
@@ -53,7 +53,8 @@ struct SPLocationPermission: SPPermissionProtocol {
     }
     
     var isDenied: Bool {
-        return CLLocationManager.authorizationStatus() == .denied
+        let authorizationStatus = CLLocationManager.authorizationStatus()
+        return authorizationStatus == .denied || authorizationStatus == .restricted
     }
     
     func request(completion: @escaping ()->()?) {


### PR DESCRIPTION
Hello.
Thank you for SPPermissions.
Found out that `CLAuthorizationStatus.restricted` is not handled. I think it should be handled the same way as `CLAuthorizationStatus.denied`.