### PR TITLE
Add a permission request hook to allow permission request pre-processing

### DIFF
--- a/Source/SPPermissions/Interface/List/Controllers/SPPermissionsListController.swift
+++ b/Source/SPPermissions/Interface/List/Controllers/SPPermissionsListController.swift
@@ -101,8 +101,13 @@ public class SPPermissionsListController: UITableViewController, SPPermissionsCo
      */
     @objc func process(button: SPPermissionActionButton) {
         let permission = button.permission
+        delegate?.willAccess?(permission: permission) { [weak self] in
+            self?.processPermission(permission, button: button)
+        }
+    }
+    
+    private func processPermission(_ permission: SPPermission, button: SPPermissionActionButton) {
         permission.request {
-            
             button.update()
             let isAuthorized = permission.isAuthorized
             if isAuthorized { SPPermissionsHaptic.impact(.light) }

--- a/Source/SPPermissions/Permissions/SPBluetoothPermission.swift
+++ b/Source/SPPermissions/Permissions/SPBluetoothPermission.swift
@@ -41,7 +41,9 @@ struct SPBluetoothPermission: SPPermissionProtocol {
     }
     
     func request(completion: @escaping ()->()?) {
-        fatalError("SPPerission - Request for Bluetooth not implement, if you know how add request, paste code here and create pull request. Also you can write me, I add code manually. Thanks!")
+        DispatchQueue.main.async {
+            completion()
+        }
     }
 }
 

--- a/Source/SPPermissions/Permissions/SPBluetoothPermission.swift
+++ b/Source/SPPermissions/Permissions/SPBluetoothPermission.swift
@@ -41,9 +41,7 @@ struct SPBluetoothPermission: SPPermissionProtocol {
     }
     
     func request(completion: @escaping ()->()?) {
-        DispatchQueue.main.async {
-            completion()
-        }
+       print("SPPerission - Request for Bluetooth not implement, if you know how add request, paste code here and create pull request. Also you can write me, I add code manually. Thanks!")
     }
 }
 

--- a/Source/SPPermissions/Permissions/SPBluetoothPermission.swift
+++ b/Source/SPPermissions/Permissions/SPBluetoothPermission.swift
@@ -42,6 +42,9 @@ struct SPBluetoothPermission: SPPermissionProtocol {
     
     func request(completion: @escaping ()->()?) {
        print("SPPerission - Request for Bluetooth not implement, if you know how add request, paste code here and create pull request. Also you can write me, I add code manually. Thanks!")
+       DispatchQueue.main.async {
+           completion()
+       }
     }
 }
 

--- a/Source/SPPermissions/Protocols/SPPermissionsDelegate.swift
+++ b/Source/SPPermissions/Protocols/SPPermissionsDelegate.swift
@@ -33,7 +33,7 @@ import UIKit
      */
     @objc optional func didAllow(permission: SPPermission)
     
-    @objc optional func willAccess(permission: SPPermission, completion: () -> ())
+    @objc optional func willAccess(permission: SPPermission, completion: @escaping () -> ())
     
     /**
      Call when permission denied.

--- a/Source/SPPermissions/Protocols/SPPermissionsDelegate.swift
+++ b/Source/SPPermissions/Protocols/SPPermissionsDelegate.swift
@@ -33,6 +33,8 @@ import UIKit
      */
     @objc optional func didAllow(permission: SPPermission)
     
+    @objc optional func willAccess(permission: SPPermission, completion: () -> ())
+    
     /**
      Call when permission denied.
      


### PR DESCRIPTION
This pull request adds a new `SPPermissionsDelegate` method which is called before the framework starts processing the permission request. 
This gives the API consumers a chance to manually attempt to request necessary permissions, e.g try to start a Bluetooth scan to force the system to display the permissions dialog. If the developer doesn't want to do any request pre-processing, they could just call the `completion` closure

Example:
```swift
func willAccess(permission: SPPermission, completion: @escaping () -> Void) {
   switch permission {
     case .bluetooth:
         BluetoothManager.requestBluetoothPermissions(completion)
    default:
        completion()
    }
}
```