### PR TITLE
Uncomment Tracking permission

### DIFF
--- a/Sources/SPPermissions/Models/SPPermission.swift
+++ b/Sources/SPPermissions/Models/SPPermission.swift
@@ -202,8 +202,7 @@ extension SPPermission {
             #endif
         case .tracking:
             #if SPPERMISSION_TRACKING
-            fatalError("Now not supported Tracking. Only in Beta now.")
-            /*return SPTrackingPermission()*/
+            return SPTrackingPermission()
             #else
             fatalError(error(permission))
             #endif

--- a/Sources/SPPermissions/Permissions/SPTrackingPermission.swift
+++ b/Sources/SPPermissions/Permissions/SPTrackingPermission.swift
@@ -17,11 +17,10 @@
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE. 
+// SOFTWARE.
 
 #if SPPERMISSION_TRACKING
 
-/*
 import AppTrackingTransparency
 import UIKit
 
@@ -33,7 +32,7 @@ struct SPTrackingPermission: SPPermissionProtocol {
             return false
         }
     }
-    
+
     var isDenied: Bool {
         if #available(iOS 14, tvOS 14, *) {
             return ATTrackingManager.trackingAuthorizationStatus == .denied
@@ -41,7 +40,7 @@ struct SPTrackingPermission: SPPermissionProtocol {
             return false
         }
     }
-    
+
     func request(completion: @escaping () -> Void?) {
         if #available(iOS 14, tvOS 14, *) {
             ATTrackingManager.requestTrackingAuthorization { _ in
@@ -52,6 +51,5 @@ struct SPTrackingPermission: SPPermissionProtocol {
         }
     }
 }
- */
 
 #endif


### PR DESCRIPTION
This is a follow up of #200. 

As iOS 14 has been released for several months, I think it's time to make `SPTrackingPermission` available. 
This reverts commit e4b6ac6e5c2acb0ea9246f9cefe3b93f24aba0b9.

Closes #222