### PR TITLE
Correct URL for Swift Package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The [Swift Package Manager](https://swift.org/package-manager/) is a tool for ma
 To integrate `SPPermissions` using Xcode 12, specify it in `File > Swift Packages > Add Package Dependency...`:
 
 ```ogdl
-https://github.com/ivanvorobei/SPPermissions
+https://github.com/ivanvorobei/SPPermissions.git
 ```
 
 Next choose the permissions you need. But don't add all of them, because apple will reject your app.


### PR DESCRIPTION
Xcode 13 does not recognize the url without the *.git* extension.

## Goal
<!--- Provide details about reason changes. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Testing in compability platforms
- [ ] Installed correct via Swift Package Manager and Cocoapods
