### PR TITLE
Fix FaceID Permission Always .notDetermined

### DIFF
--- a/Sources/SPPermissionsFaceID/SPFaceIDPermission.swift
+++ b/Sources/SPPermissionsFaceID/SPFaceIDPermission.swift
@@ -52,7 +52,7 @@ public class SPFaceIDPermission: SPPermissions.Permission {
         
         switch error?.code {
             case nil where isReady:
-                return .notDetermined
+                return .authorized
             case LAError.biometryNotAvailable.rawValue:
                 return .denied
             case LAError.biometryNotEnrolled.rawValue:


### PR DESCRIPTION
Since the error is `nil` and `isReady` is `true`, actually its authorized :)

## Goal

Face ID is always returning `.notDetermined`. This PR should fix.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Testing in compability platforms
- [x] Installed correct via Swift Package Manager and Cocoapods
